### PR TITLE
fix: add types export to exports object

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "module": "./dist/ts-jest-mock.es.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/ts-jest-mock.es.js",
       "require": "./dist/ts-jest-mock.umd.js"
     }


### PR DESCRIPTION
Add types export to exports field so TypeScript 4.7 is able to the the types when using the module resolution for Node 16+.

The `types` inside the `exports` object has to be first for TypeScript to be happy (see this issue: https://github.com/microsoft/TypeScript/issues/46334).